### PR TITLE
Make no suffix a possibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.samaxes.maven</groupId>
     <artifactId>minify-maven-plugin</artifactId>
-    <version>1.6.1-SNAPSHOT</version>
+    <version>1.6.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Minify Maven Plugin</name>

--- a/src/main/java/com/samaxes/maven/minify/plugin/MinifyMojo.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/MinifyMojo.java
@@ -145,7 +145,7 @@ public class MinifyMojo extends AbstractMojo {
     /**
      * The output filename suffix.
      *
-     * @parameter expression="${suffix}" default-value=".min"
+     * @parameter expression="${suffix}" default-value=""
      * @since 1.3.2
      */
     private String suffix;
@@ -272,6 +272,10 @@ public class MinifyMojo extends AbstractMojo {
         if (skipMerge && skipMinify) {
             getLog().warn("Both merge and minify steps are configured to be skipped.");
             return;
+        }
+        
+        if (suffix == null) {
+            suffix = "";
         }
 
         Collection<ProcessFilesTask> processFilesTasks = new ArrayList<ProcessFilesTask>();


### PR DESCRIPTION
Changed default suffix to an empty string to give users the option to have no suffix at all.

Because maven interprets an empty string as null, added a check to make
sure suffix is not null, and to set it to an empty string if it is.
