### PR TITLE
Change suffix handling to permit alternative naming schemes

### DIFF
--- a/src/main/java/com/samaxes/maven/minify/plugin/MinifyMojo.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/MinifyMojo.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.regex.Pattern;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -48,6 +49,8 @@ import com.samaxes.maven.minify.common.YuiConfig;
  */
 @Mojo(name = "minify", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, threadSafe = true)
 public class MinifyMojo extends AbstractMojo {
+
+    private static Pattern LEGACY_SUFFIX = Pattern.compile("^[a-z0-9].*$", Pattern.CASE_INSENSITIVE);
 
     /**
      * Engine used for minification
@@ -101,7 +104,7 @@ public class MinifyMojo extends AbstractMojo {
      *
      * @since 1.3.2
      */
-    @Parameter(property = "suffix", defaultValue = "min")
+    @Parameter(property = "suffix", defaultValue = ".min")
     private String suffix;
 
     /**
@@ -414,6 +417,11 @@ public class MinifyMojo extends AbstractMojo {
         if (skipMerge && skipMinify) {
             getLog().warn("Both merge and minify steps are configured to be skipped.");
             return;
+        }
+
+        // If suffix starts with a alphanumeric char, default to prefixing it with a dot.
+        if (LEGACY_SUFFIX.matcher(suffix).matches()) {
+            suffix = "." + suffix;
         }
 
         fillOptionalValues();

--- a/src/main/java/com/samaxes/maven/minify/plugin/ProcessFilesTask.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/ProcessFilesTask.java
@@ -161,8 +161,10 @@ public abstract class ProcessFilesTask implements Callable<Object> {
                         File targetPath = new File(targetDir.getAbsolutePath() + subPath);
                         targetPath.mkdirs();
 
+                        String mergedFileBasename = FileUtils.basename(mergedFile.getName());
+                        mergedFileBasename = mergedFileBasename.substring(0, mergedFileBasename.length() - 1);
                         File minifiedFile = new File(targetPath, (nosuffix) ? mergedFile.getName()
-                                : FileUtils.basename(mergedFile.getName()) + suffix
+                                : mergedFileBasename + suffix
                                         + FileUtils.getExtension(mergedFile.getName()));
                         minify(mergedFile, minifiedFile);
                     }


### PR DESCRIPTION
Had a need for this plugin to output unmerged minified files with the name `foo-min.js`, rather than `foo.min.js`.