### PR TITLE
JavaScript Source map generated by Closure compiler now can have links t...

### DIFF
--- a/src/main/java/com/samaxes/maven/minify/common/ClosureConfig.java
+++ b/src/main/java/com/samaxes/maven/minify/common/ClosureConfig.java
@@ -46,6 +46,8 @@ public class ClosureConfig {
 
     private final Boolean angularPass;
 
+    private final Boolean mapToOriginalSourceFiles;
+
     /**
      * Init Closure Compiler values.
      *
@@ -56,9 +58,10 @@ public class ClosureConfig {
      * @param useDefaultExterns use default externs packed with the Closure Compiler
      * @param createSourceMap create a source map for the minifed/combined production files
      * @param angularPass use {@code @ngInject} annotation to generate Angular injections
+     * @param mapToOriginalSourceFiles if true, do not merge the source js files and create a link to each of them in the source map 
      */
     public ClosureConfig(LanguageMode language, CompilationLevel compilationLevel, DependencyOptions dependencyOptions,
-            List<SourceFile> externs, boolean useDefaultExterns, boolean createSourceMap, boolean angularPass) {
+            List<SourceFile> externs, boolean useDefaultExterns, boolean createSourceMap, boolean angularPass, boolean mapToOriginalSourceFiles) {
         this.language = language;
         this.compilationLevel = compilationLevel;
         this.dependencyOptions = dependencyOptions;
@@ -66,6 +69,7 @@ public class ClosureConfig {
         this.useDefaultExterns = useDefaultExterns;
         this.sourceMapFormat = (createSourceMap) ? SourceMap.Format.V3 : null;
         this.angularPass = angularPass;
+        this.mapToOriginalSourceFiles = createSourceMap && mapToOriginalSourceFiles;
     }
 
     /**
@@ -130,4 +134,14 @@ public class ClosureConfig {
     public Boolean getAngularPass() {
         return angularPass;
     }
+
+    /**
+     * Gets the mapToOriginalSourceFiles
+     * 
+     * @return the mapToOriginalSourceFiles
+     */
+    public Boolean getMapToOriginalSourceFiles() {
+        return mapToOriginalSourceFiles;
+    }
+
 }

--- a/src/main/java/com/samaxes/maven/minify/plugin/MinifyMojo.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/MinifyMojo.java
@@ -434,6 +434,17 @@ public class MinifyMojo extends AbstractMojo {
 
     /**
      * <p>
+     * If true, the source map created by the Closure compiler will have one link to each of the original JavaScript
+     * source files
+     * </p>
+     *
+     * @since 1.7.5-SNAPSHOT
+     */
+    @Parameter(property = "closureMapToOriginalSourceFiles", defaultValue = "false")
+    private boolean closureMapToOriginalSourceFiles;
+
+    /**
+     * <p>
      * Enables or disables sorting mode for Closure Library dependencies.
      * </p>
      * <p>
@@ -553,7 +564,7 @@ public class MinifyMojo extends AbstractMojo {
         }
 
         return new ClosureConfig(closureLanguage, closureCompilationLevel, dependencyOptions, externs,
-                closureUseDefaultExterns, closureCreateSourceMap, closureAngularPass);
+                closureUseDefaultExterns, closureCreateSourceMap, closureAngularPass, closureMapToOriginalSourceFiles);
     }
 
     private Collection<ProcessFilesTask> createTasks(YuiConfig yuiConfig, ClosureConfig closureConfig)

--- a/src/main/java/com/samaxes/maven/minify/plugin/ProcessCSSFilesTask.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/ProcessCSSFilesTask.java
@@ -70,7 +70,7 @@ public class ProcessCSSFilesTask extends ProcessFilesTask {
             String outputDir, String outputFilename, Engine engine, YuiConfig yuiConfig) throws FileNotFoundException {
         super(log, verbose, bufferSize, charset, suffix, nosuffix, skipMerge, skipMinify, webappSourceDir,
                 webappTargetDir, inputDir, sourceFiles, sourceIncludes, sourceExcludes, outputDir, outputFilename,
-                engine, yuiConfig);
+                engine, yuiConfig, null);
     }
 
     /**
@@ -109,5 +109,10 @@ public class ProcessCSSFilesTask extends ProcessFilesTask {
         }
 
         logCompressionGains(mergedFile, minifiedFile);
+    }
+
+    @Override
+    void minify(List<File> srcFiles, File minifiedFile) throws IOException {
+        throw new RuntimeException("Compressing a list of css files is not supported by this version.");
     }
 }

--- a/src/main/java/com/samaxes/maven/minify/plugin/ProcessFilesTask.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/ProcessFilesTask.java
@@ -40,6 +40,7 @@ import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 
+import com.samaxes.maven.minify.common.ClosureConfig;
 import com.samaxes.maven.minify.common.SourceFilesEnumeration;
 import com.samaxes.maven.minify.common.YuiConfig;
 import com.samaxes.maven.minify.plugin.MinifyMojo.Engine;
@@ -83,6 +84,8 @@ public abstract class ProcessFilesTask implements Callable<Object> {
 
     private final boolean sourceIncludesEmpty;
 
+    protected final ClosureConfig closureConfig;
+
     /**
      * Task constructor.
      *
@@ -105,12 +108,13 @@ public abstract class ProcessFilesTask implements Callable<Object> {
      * @param outputFilename the output file name
      * @param engine minify processor engine selected
      * @param yuiConfig YUI Compressor configuration
+     * @param closureConfig Google closure configuration
      * @throws FileNotFoundException when the given source file does not exist
      */
     public ProcessFilesTask(Log log, boolean verbose, Integer bufferSize, String charset, String suffix,
             boolean nosuffix, boolean skipMerge, boolean skipMinify, String webappSourceDir, String webappTargetDir,
             String inputDir, List<String> sourceFiles, List<String> sourceIncludes, List<String> sourceExcludes,
-            String outputDir, String outputFilename, Engine engine, YuiConfig yuiConfig) throws FileNotFoundException {
+            String outputDir, String outputFilename, Engine engine, YuiConfig yuiConfig, ClosureConfig closureConfig) throws FileNotFoundException {
         this.log = log;
         this.verbose = verbose;
         this.bufferSize = bufferSize;
@@ -135,6 +139,7 @@ public abstract class ProcessFilesTask implements Callable<Object> {
         }
         this.sourceFilesEmpty = sourceFiles.isEmpty();
         this.sourceIncludesEmpty = sourceIncludes.isEmpty();
+        this.closureConfig = closureConfig;
     }
 
     /**
@@ -149,7 +154,16 @@ public abstract class ProcessFilesTask implements Callable<Object> {
             log.info("Starting " + fileType + " task:");
 
             if (!files.isEmpty() && (targetDir.exists() || targetDir.mkdirs())) {
-                if (skipMerge) {
+
+                if (fileType.equals("JavaScript") && this.engine == Engine.CLOSURE
+                        && closureConfig.getMapToOriginalSourceFiles()) {
+
+                    File minifiedFile = new File(targetDir, (nosuffix) ? mergedFilename
+                            : FileUtils.basename(mergedFilename) + suffix + FileUtils.getExtension(mergedFilename));
+
+                    minify(files, minifiedFile);
+
+                } else if (skipMerge) {
                     log.info("Skipping the merge step...");
                     String sourceBasePath = sourceDir.getAbsolutePath();
 
@@ -224,12 +238,33 @@ public abstract class ProcessFilesTask implements Callable<Object> {
     abstract void minify(File mergedFile, File minifiedFile) throws IOException;
 
     /**
+     * Minifies a list of source files into a single file. Create missing parent directories if needed.
+     *
+     * @param srcFiles list of input files
+     * @param minifiedFile output file resulting from the minify step
+     * @throws IOException when the minify step fails
+     */
+    abstract void minify(List<File> srcFiles, File minifiedFile) throws IOException;
+
+    /**
      * Logs compression gains.
      *
      * @param mergedFile input file resulting from the merged step
      * @param minifiedFile output file resulting from the minify step
      */
     void logCompressionGains(File mergedFile, File minifiedFile) {
+        List<File> srcFiles = new ArrayList<File>();
+        srcFiles.add(mergedFile);
+        logCompressionGains(srcFiles, minifiedFile);
+    }
+
+    /**
+     * Logs compression gains.
+     *
+     * @param srcFiles list of input files to compress
+     * @param minifiedFile output file resulting from the minify step
+     */
+    void logCompressionGains(List<File> srcFiles, File minifiedFile) {
         try {
             File temp = File.createTempFile(minifiedFile.getName(), ".gz");
 
@@ -239,7 +274,14 @@ public abstract class ProcessFilesTask implements Callable<Object> {
                 IOUtil.copy(in, outGZIP, bufferSize);
             }
 
-            log.info("Uncompressed size: " + mergedFile.length() + " bytes.");
+            long uncompressedSize = 0;
+            if (srcFiles != null) {
+                for (File srcFile : srcFiles) {
+                    uncompressedSize += srcFile.length();
+                }
+            }
+
+            log.info("Uncompressed size: " + uncompressedSize + " bytes.");
             log.info("Compressed size: " + minifiedFile.length() + " bytes minified (" + temp.length()
                     + " bytes gzipped).");
 


### PR DESCRIPTION
...o

each source file instead of one link to the merged file. This may be
useful when debugging many JavaScript source files.
This is configured with the option closureMapToOriginalSourceFiles = true
