### PR TITLE
Print syntax errors with sourceName, lineNumber, and description

### DIFF
--- a/src/main/java/com/samaxes/maven/minify/plugin/ProcessJSFilesTask.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/ProcessJSFilesTask.java
@@ -37,6 +37,7 @@ import com.google.common.collect.Lists;
 import com.google.javascript.jscomp.CommandLineRunner;
 import com.google.javascript.jscomp.Compiler;
 import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.JSError;
 import com.google.javascript.jscomp.SourceFile;
 import com.google.javascript.jscomp.SourceMap;
 import com.samaxes.maven.minify.common.ClosureConfig;
@@ -136,6 +137,13 @@ public class ProcessJSFilesTask extends ProcessFilesTask {
                     compiler.compile(externs, Lists.newArrayList(input), options);
 
                     if (compiler.hasErrors()) {
+                        if (this.verbose) {
+                            for (JSError err : compiler.getErrors()) {
+                                System.out.println("Syntax error (" + err.sourceName
+                                        + ":" + err.lineNumber + ") - "
+                                        + err.description);
+                            }
+                        }
                         throw new EvaluatorException(compiler.getErrors()[0].description);
                     }
 


### PR DESCRIPTION
As per issue #109 

Couldn't figure out why Eclipse was formatting all lines of the file, but I've only added one import for JSError at line 40 and a small code block to print errors from 140-146.

Note that I've left the thrown exception at line 147 for simplicity.

Cheers!