### PR TITLE
Adding configuration option for closure extra annotations

### DIFF
--- a/src/main/java/com/samaxes/maven/minify/common/ClosureConfig.java
+++ b/src/main/java/com/samaxes/maven/minify/common/ClosureConfig.java
@@ -46,6 +46,8 @@ public class ClosureConfig {
 
     private final Boolean angularPass;
 
+    private final List<String> extraAnnotations;
+
     /**
      * Init Closure Compiler values.
      *
@@ -56,9 +58,11 @@ public class ClosureConfig {
      * @param useDefaultExterns use default externs packed with the Closure Compiler
      * @param createSourceMap create a source map for the minifed/combined production files
      * @param angularPass use {@code @ngInject} annotation to generate Angular injections
+     * @param extraAnnotations make extra annotations known to the closure engine
      */
     public ClosureConfig(LanguageMode language, CompilationLevel compilationLevel, DependencyOptions dependencyOptions,
-            List<SourceFile> externs, boolean useDefaultExterns, boolean createSourceMap, boolean angularPass) {
+            List<SourceFile> externs, boolean useDefaultExterns, boolean createSourceMap, boolean angularPass,
+            List<String> extraAnnotations) {
         this.language = language;
         this.compilationLevel = compilationLevel;
         this.dependencyOptions = dependencyOptions;
@@ -66,6 +70,7 @@ public class ClosureConfig {
         this.useDefaultExterns = useDefaultExterns;
         this.sourceMapFormat = (createSourceMap) ? SourceMap.Format.V3 : null;
         this.angularPass = angularPass;
+        this.extraAnnotations = extraAnnotations;
     }
 
     /**
@@ -130,4 +135,13 @@ public class ClosureConfig {
     public Boolean getAngularPass() {
         return angularPass;
     }
+
+	/**
+	 * Gets the extraAnnotations.
+	 *
+	 * @return the extraAnnotations
+	 */
+	public List<String> getExtraAnnotations() {
+		return extraAnnotations;
+	}
 }

--- a/src/main/java/com/samaxes/maven/minify/plugin/MinifyMojo.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/MinifyMojo.java
@@ -454,6 +454,14 @@ public class MinifyMojo extends AbstractMojo {
     private boolean closureAngularPass;
 
     /**
+     * List of extra annotations to make them known to the closure engine.
+     *
+     * @since 1.7.5
+     */
+    @Parameter(property = "closureExtraAnnotations")
+    private ArrayList<String> closureExtraAnnotations;
+
+    /**
      * Executed when the goal is invoked, it will first invoke a parallel lifecycle, ending at the given phase.
      */
     @Override
@@ -552,7 +560,7 @@ public class MinifyMojo extends AbstractMojo {
         }
 
         return new ClosureConfig(closureLanguage, closureCompilationLevel, dependencyOptions, externs,
-                closureUseDefaultExterns, closureCreateSourceMap, closureAngularPass);
+                closureUseDefaultExterns, closureCreateSourceMap, closureAngularPass, closureExtraAnnotations);
     }
 
     private Collection<ProcessFilesTask> createTasks(YuiConfig yuiConfig, ClosureConfig closureConfig)

--- a/src/main/java/com/samaxes/maven/minify/plugin/ProcessJSFilesTask.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/ProcessJSFilesTask.java
@@ -117,6 +117,7 @@ public class ProcessJSFilesTask extends ProcessFilesTask {
                     options.setLanguageIn(closureConfig.getLanguage());
                     options.setAngularPass(closureConfig.getAngularPass());
                     options.setDependencyOptions(closureConfig.getDependencyOptions());
+                    options.setExtraAnnotationNames(closureConfig.getExtraAnnotations());
 
                     File sourceMapResult = new File(minifiedFile.getPath() + ".map");
                     if (closureConfig.getSourceMapFormat() != null) {


### PR DESCRIPTION

Hi,

This PR will fix issue #83.

It is now possible to configure closure to give it a list of extra annotations so it stops printing warnings for each of them.

Thanks