### PR TITLE
ES6+ support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.samaxes.maven</groupId>
     <artifactId>minify-maven-plugin</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>Minify Maven Plugin</name>
@@ -82,13 +82,13 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.3.9</version>
+            <version>3.6.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.5</version>
+            <version>3.6.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- Compile -->
@@ -101,13 +101,13 @@
         <dependency>
             <groupId>com.google.javascript</groupId>
             <artifactId>closure-compiler</artifactId>
-            <version>v20161024</version>
+            <version>v20210302</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
+            <version>2.8.6</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/src/main/java/com/samaxes/maven/minify/common/ClosureConfig.java
+++ b/src/main/java/com/samaxes/maven/minify/common/ClosureConfig.java
@@ -18,10 +18,10 @@
  */
 package com.samaxes.maven.minify.common;
 
-import com.google.common.base.Strings;
 import com.google.javascript.jscomp.*;
 import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import com.google.javascript.jscomp.SourceMap.Format;
+import com.google.javascript.jscomp.jarjar.com.google.common.base.Strings;
 
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/samaxes/maven/minify/plugin/ProcessJSFilesTask.java
+++ b/src/main/java/com/samaxes/maven/minify/plugin/ProcessJSFilesTask.java
@@ -18,9 +18,10 @@
  */
 package com.samaxes.maven.minify.plugin;
 
-import com.google.common.collect.Lists;
 import com.google.javascript.jscomp.*;
 import com.google.javascript.jscomp.Compiler;
+import com.google.javascript.jscomp.jarjar.com.google.common.collect.ImmutableList;
+import com.google.javascript.jscomp.jarjar.com.google.common.collect.Lists;
 import com.samaxes.maven.minify.common.ClosureConfig;
 import com.samaxes.maven.minify.common.JavaScriptErrorReporter;
 import com.samaxes.maven.minify.common.YuiConfig;
@@ -137,8 +138,8 @@ public class ProcessJSFilesTask extends ProcessFilesTask {
                     compiler.compile(externs, Lists.newArrayList(input), options);
 
                     // Check for errors.
-                    JSError[] errors = compiler.getErrors();
-                    if (errors.length > 0) {
+                    ImmutableList<JSError> errors = compiler.getErrors();
+                    if (errors.size() > 0) {
                         StringBuilder msg = new StringBuilder("JSCompiler errors\n");
                         MessageFormatter formatter = new LightweightMessageFormatter(compiler);
                         for (JSError e : errors) {


### PR DESCRIPTION
Updated Google Closure Compiler version to v20210302; Have set default jsEngine as CLOSURE and closureLanguageIn default as ES_2020; Tiny refactoring