### PR TITLE
Fix compatibility with Maven 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
             <scope>provided</scope>
         </dependency>
         <!-- Compile -->
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.5.0</version>
+        </dependency>
         <dependency>
             <groupId>com.yahoo.platform.yui</groupId>
             <artifactId>yuicompressor</artifactId>


### PR DESCRIPTION
Since Maven 3.9, plexus-utils are not injected automatically anymore. Plugins are now required to declare plexus-utils as an explicit dependency if they need to use it. See https://maven.apache.org/docs/3.9.0/release-notes.html

> Maven 2.x was auto-injecting an ancient version of plexus-utils dependency into the plugin classpath, and Maven 3.x continued doing this to preserve backward compatibility. Starting with Maven 3.9, it does not happen anymore. This change may lead to plugin breakage. The fix for affected plugin maintainers is to explicitly declare a dependency on plexus-utils. The workaround for affected plugin users is to add this dependency to plugin dependencies until issue is fixed by the affected plugin maintainer. See MNG-6965.